### PR TITLE
Add option `pull-branch-tags` to pull command

### DIFF
--- a/README.md
+++ b/README.md
@@ -150,6 +150,12 @@ It will pull the images from the remote registry
 
 By default it pulls the 'latest' and the 'branch' docker tags.
 
+Flags:
+
+```
+--pull-branch-tags=true: Pull the 'branch' docker tags
+```
+
 ## version
 
 Display version

--- a/captain.go
+++ b/captain.go
@@ -154,16 +154,22 @@ func Push(opts BuildOptions) {
 	}
 }
 
+type PullOptions struct {
+	Pull_branch_tags bool
+}
+
 // Pull function pulls the containers from the remote registry
-func Pull(opts BuildOptions) {
+func Pull(opts BuildOptions, pullOpts PullOptions) {
 	config := opts.Config
 
 	for _, app := range config.GetApps() {
 		for _,branch := range getBranches(opts.All_branches) {
 			info("Pulling image %s:%s", app.Image, "latest")
 			execute("docker", "pull", app.Image+":"+"latest")
-			info("Pulling image %s:%s", app.Image, branch)
-			execute("docker", "pull", app.Image+":"+branch)
+			if pullOpts.Pull_branch_tags == true {
+				info("Pulling image %s:%s", app.Image, branch)
+				execute("docker", "pull", app.Image+":"+branch)
+			}
 		}
 	}
 }

--- a/cmd/captain/cmd.go
+++ b/cmd/captain/cmd.go
@@ -22,6 +22,12 @@ type Options struct {
 
 var options Options
 
+type PullOptions struct {
+	pull_branch_tags bool
+}
+
+var pullOptions PullOptions
+
 func handleCmd() {
 
 	var cmdBuild = &cobra.Command{
@@ -112,7 +118,11 @@ func handleCmd() {
 				Long_sha: options.long_sha,
 			}
 
-			captain.Pull(buildOpts)
+			pullOpts := captain.PullOptions{
+				Pull_branch_tags: pullOptions.pull_branch_tags,
+			}
+
+			captain.Pull(buildOpts, pullOpts)
 		},
 	}
 
@@ -163,6 +173,7 @@ It works by reading captain.yaml file which describes how to build, test, push a
 	captainCmd.PersistentFlags().BoolVarP(&options.long_sha, "long-sha", "l", false, "Use the long git commit SHA when referencing revisions")
 	cmdBuild.Flags().BoolVarP(&options.force, "force", "f", false, "Force build even if image is already built")
 	cmdPurge.Flags().BoolVarP(&options.force, "dangling", "d", false, "Remove dangling images")
+	cmdPull.Flags().BoolVar(&pullOptions.pull_branch_tags, "pull-branch-tags", true, "Pull the 'branch' docker tags")
 	captainCmd.AddCommand(cmdBuild, cmdTest, cmdPush, cmdPull, cmdVersion, cmdPurge)
 	captainCmd.Execute()
 }


### PR DESCRIPTION
in order to allow disabling of pull 'branch' docker tags behaviour.
PTAL: @spiddy