### PR TITLE
#32 add --commit-tags flag to push and pull commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,6 +125,7 @@ It will build the docker image(s) described on captain.yml in order they appear 
 Flags:
 
 ```
+-B, --all-branches=false: Build all branches on specific commit instead of just working branch
 -f, --force=false: Force build even if image is already built
 ```
 
@@ -142,6 +143,14 @@ It will push the generated images to the remote registry
 
 By default it pushes the 'latest' and the 'branch' docker tags.
 
+Flags:
+
+```
+-B, --all-branches=false: Push all branches on specific commit instead of just working branch
+-b, --branch-tags=true: Push the 'branch' docker tags
+-c, --commit-tags=false: Push the 'commit' docker tags
+```
+
 ## pull
 
 Pulls the images from remote registry
@@ -153,7 +162,9 @@ By default it pulls the 'latest' and the 'branch' docker tags.
 Flags:
 
 ```
---pull-branch-tags=true: Pull the 'branch' docker tags
+-B, --all-branches=false: Pull all branches on specific commit instead of just working branch
+-b, --branch-tags=true: Pull the 'branch' docker tags
+-c, --commit-tags=false: Pull the 'commit' docker tags
 ```
 
 ## version
@@ -171,7 +182,6 @@ Simply type `captain help [path to command]` for full details.
 ## Global CLI Flags
 
 ```
--B, --all-branches=false: Build all branches on specific commit instead of just working branch
 -D, --debug=false: Enable debug mode
 -h, --help=false: help for captain
 -N, --namespace="username": Set default image namespace

--- a/captain.go
+++ b/captain.go
@@ -42,6 +42,8 @@ type BuildOptions struct {
 	Force  bool
 	All_branches bool
 	Long_sha bool
+	Branch_tags bool
+	Commit_tags bool
 }
 
 // Build function compiles the Containers of the project
@@ -129,12 +131,8 @@ func Test(opts BuildOptions) {
 	}
 }
 
-type PushOptions struct {
-	Enable_commit_id bool
-}
-
 // Push function pushes the containers to the remote registry
-func Push(opts BuildOptions, pushOpts PushOptions) {
+func Push(opts BuildOptions) {
 	config := opts.Config
 
 	// If no Git repo exist
@@ -154,36 +152,31 @@ func Push(opts BuildOptions, pushOpts PushOptions) {
 			execute("docker", "push", app.Image+":"+branch)
 			info("Pushing image %s:%s", app.Image, "latest")
 			execute("docker", "push", app.Image+":"+"latest")
-			if (pushOpts.Enable_commit_id) {
-				commit_id := getRevision(opts.Long_sha)
-				info("Pushing image %s:%s", app.Image, commit_id)
-				execute("docker", "push", app.Image+":"+commit_id)
+			if opts.Commit_tags {
+				rev := getRevision(opts.Long_sha)
+				info("Pushing image %s:%s", app.Image, rev)
+				execute("docker", "push", app.Image+":"+rev)
 			}
 		}
 	}
 }
 
-type PullOptions struct {
-	Pull_branch_tags bool
-	Enable_commit_id bool
-}
-
 // Pull function pulls the containers from the remote registry
-func Pull(opts BuildOptions, pullOpts PullOptions) {
+func Pull(opts BuildOptions) {
 	config := opts.Config
 
 	for _, app := range config.GetApps() {
 		for _,branch := range getBranches(opts.All_branches) {
 			info("Pulling image %s:%s", app.Image, "latest")
 			execute("docker", "pull", app.Image+":"+"latest")
-			if pullOpts.Pull_branch_tags == true {
+			if opts.Branch_tags {
 				info("Pulling image %s:%s", app.Image, branch)
 				execute("docker", "pull", app.Image+":"+branch)
 			}
-			if pullOpts.Enable_commit_id == true {
-				commit_id := getRevision(opts.Long_sha)
-				info("Pulling image %s:%s", app.Image, commit_id)
-				execute("docker", "pull", app.Image+":"+commit_id)
+			if opts.Commit_tags {
+				rev := getRevision(opts.Long_sha)
+				info("Pulling image %s:%s", app.Image, rev)
+				execute("docker", "pull", app.Image+":"+rev)
 			}
 		}
 	}

--- a/captain.go
+++ b/captain.go
@@ -129,8 +129,12 @@ func Test(opts BuildOptions) {
 	}
 }
 
+type PushOptions struct {
+	Enable_commit_id bool
+}
+
 // Push function pushes the containers to the remote registry
-func Push(opts BuildOptions) {
+func Push(opts BuildOptions, pushOpts PushOptions) {
 	config := opts.Config
 
 	// If no Git repo exist
@@ -150,6 +154,11 @@ func Push(opts BuildOptions) {
 			execute("docker", "push", app.Image+":"+branch)
 			info("Pushing image %s:%s", app.Image, "latest")
 			execute("docker", "push", app.Image+":"+"latest")
+			if (pushOpts.Enable_commit_id) {
+				commit_id := getRevision(opts.Long_sha)
+				info("Pushing image %s:%s", app.Image, commit_id)
+				execute("docker", "push", app.Image+":"+commit_id)
+			}
 		}
 	}
 }

--- a/captain.go
+++ b/captain.go
@@ -148,10 +148,12 @@ func Push(opts BuildOptions) {
 
 	for _, app := range config.GetApps() {
 		for _,branch := range getBranches(opts.All_branches) {
-			info("Pushing image %s:%s", app.Image, branch)
-			execute("docker", "push", app.Image+":"+branch)
 			info("Pushing image %s:%s", app.Image, "latest")
 			execute("docker", "push", app.Image+":"+"latest")
+			if opts.Branch_tags {
+				info("Pushing image %s:%s", app.Image, branch)
+				execute("docker", "push", app.Image+":"+branch)
+			}
 			if opts.Commit_tags {
 				rev := getRevision(opts.Long_sha)
 				info("Pushing image %s:%s", app.Image, rev)

--- a/captain.go
+++ b/captain.go
@@ -165,6 +165,7 @@ func Push(opts BuildOptions, pushOpts PushOptions) {
 
 type PullOptions struct {
 	Pull_branch_tags bool
+	Enable_commit_id bool
 }
 
 // Pull function pulls the containers from the remote registry
@@ -178,6 +179,11 @@ func Pull(opts BuildOptions, pullOpts PullOptions) {
 			if pullOpts.Pull_branch_tags == true {
 				info("Pulling image %s:%s", app.Image, branch)
 				execute("docker", "pull", app.Image+":"+branch)
+			}
+			if pullOpts.Enable_commit_id == true {
+				commit_id := getRevision(opts.Long_sha)
+				info("Pulling image %s:%s", app.Image, commit_id)
+				execute("docker", "pull", app.Image+":"+commit_id)
 			}
 		}
 	}

--- a/cmd/captain/cmd.go
+++ b/cmd/captain/cmd.go
@@ -24,6 +24,7 @@ var options Options
 
 type PullOptions struct {
 	pull_branch_tags bool
+	enable_commit_id bool
 }
 
 var pullOptions PullOptions
@@ -130,6 +131,7 @@ func handleCmd() {
 
 			pullOpts := captain.PullOptions{
 				Pull_branch_tags: pullOptions.pull_branch_tags,
+				Enable_commit_id: pullOptions.enable_commit_id,
 			}
 
 			captain.Pull(buildOpts, pullOpts)
@@ -184,6 +186,7 @@ It works by reading captain.yaml file which describes how to build, test, push a
 	cmdBuild.Flags().BoolVarP(&options.force, "force", "f", false, "Force build even if image is already built")
 	cmdPurge.Flags().BoolVarP(&options.force, "dangling", "d", false, "Remove dangling images")
 	cmdPull.Flags().BoolVar(&pullOptions.pull_branch_tags, "pull-branch-tags", true, "Pull the 'branch' docker tags")
+	cmdPull.Flags().BoolVar(&pullOptions.enable_commit_id, "enable-commit-id", false, "Enable pulling commit-id tag image")
 	cmdPush.Flags().BoolVar(&pushOptions.enable_commit_id, "enable-commit-id", false, "Enable pushing commit-id tag image")
 	captainCmd.AddCommand(cmdBuild, cmdTest, cmdPush, cmdPull, cmdVersion, cmdPurge)
 	captainCmd.Execute()

--- a/cmd/captain/cmd.go
+++ b/cmd/captain/cmd.go
@@ -28,6 +28,12 @@ type PullOptions struct {
 
 var pullOptions PullOptions
 
+type PushOptions struct {
+	enable_commit_id bool
+}
+
+var pushOptions PushOptions
+
 func handleCmd() {
 
 	var cmdBuild = &cobra.Command{
@@ -94,9 +100,13 @@ func handleCmd() {
 				Long_sha: options.long_sha,
 			}
 
+			pushOpts := captain.PushOptions{
+				Enable_commit_id: pushOptions.enable_commit_id,
+			}
+
 			// Build everything before pushing
 			captain.Build(buildOpts)
-			captain.Push(buildOpts)
+			captain.Push(buildOpts, pushOpts)
 		},
 	}
 
@@ -174,6 +184,7 @@ It works by reading captain.yaml file which describes how to build, test, push a
 	cmdBuild.Flags().BoolVarP(&options.force, "force", "f", false, "Force build even if image is already built")
 	cmdPurge.Flags().BoolVarP(&options.force, "dangling", "d", false, "Remove dangling images")
 	cmdPull.Flags().BoolVar(&pullOptions.pull_branch_tags, "pull-branch-tags", true, "Pull the 'branch' docker tags")
+	cmdPush.Flags().BoolVar(&pushOptions.enable_commit_id, "enable-commit-id", false, "Enable pushing commit-id tag image")
 	captainCmd.AddCommand(cmdBuild, cmdTest, cmdPush, cmdPull, cmdVersion, cmdPurge)
 	captainCmd.Execute()
 }

--- a/cmd/captain/cmd.go
+++ b/cmd/captain/cmd.go
@@ -13,27 +13,18 @@ import (
 type Options struct {
 	debug        bool
 	force        bool
-	all_branches bool
 	long_sha     bool
 	namespace    string
 	config       string
 	images       []string
+
+	// Options to define the docker tags context
+	all_branches bool
+	branch_tags bool
+	commit_tags bool
 }
 
 var options Options
-
-type PullOptions struct {
-	pull_branch_tags bool
-	enable_commit_id bool
-}
-
-var pullOptions PullOptions
-
-type PushOptions struct {
-	enable_commit_id bool
-}
-
-var pushOptions PushOptions
 
 func handleCmd() {
 
@@ -53,6 +44,8 @@ func handleCmd() {
 				Force:  options.force,
 				All_branches:  options.all_branches,
 				Long_sha: options.long_sha,
+				Branch_tags: options.branch_tags,
+				Commit_tags: options.commit_tags,
 			}
 
 			captain.Build(buildOpts)
@@ -75,6 +68,8 @@ func handleCmd() {
 				Force:  options.force,
 				All_branches:  options.all_branches,
 				Long_sha: options.long_sha,
+				Branch_tags: options.branch_tags,
+				Commit_tags: options.commit_tags,
 			}
 
 			// Build everything before testing
@@ -99,15 +94,13 @@ func handleCmd() {
 				Force:  options.force,
 				All_branches:  options.all_branches,
 				Long_sha: options.long_sha,
-			}
-
-			pushOpts := captain.PushOptions{
-				Enable_commit_id: pushOptions.enable_commit_id,
+				Branch_tags: options.branch_tags,
+				Commit_tags: options.commit_tags,
 			}
 
 			// Build everything before pushing
 			captain.Build(buildOpts)
-			captain.Push(buildOpts, pushOpts)
+			captain.Push(buildOpts)
 		},
 	}
 
@@ -127,14 +120,11 @@ func handleCmd() {
 				Force:  options.force,
 				All_branches:  options.all_branches,
 				Long_sha: options.long_sha,
+				Branch_tags: options.branch_tags,
+				Commit_tags: options.commit_tags,
 			}
 
-			pullOpts := captain.PullOptions{
-				Pull_branch_tags: pullOptions.pull_branch_tags,
-				Enable_commit_id: pullOptions.enable_commit_id,
-			}
-
-			captain.Pull(buildOpts, pullOpts)
+			captain.Pull(buildOpts)
 		},
 	}
 
@@ -181,13 +171,16 @@ It works by reading captain.yaml file which describes how to build, test, push a
 	captainCmd.PersistentFlags().BoolVarP(&captain.Debug, "debug", "D", false, "Enable debug mode")
 	captainCmd.PersistentFlags().StringVarP(&options.namespace, "namespace", "N", getNamespace(), "Set default image namespace")
 	captainCmd.PersistentFlags().BoolVarP(&color.NoColor, "no-color", "n", false, "Disable color output")
-	captainCmd.PersistentFlags().BoolVarP(&options.all_branches, "all-branches", "B", false, "Build all branches on specific commit instead of just working branch")
 	captainCmd.PersistentFlags().BoolVarP(&options.long_sha, "long-sha", "l", false, "Use the long git commit SHA when referencing revisions")
 	cmdBuild.Flags().BoolVarP(&options.force, "force", "f", false, "Force build even if image is already built")
+	cmdBuild.Flags().BoolVarP(&options.all_branches, "all-branches", "B", false, "Build all branches on specific commit instead of just working branch")
+	cmdPull.Flags().BoolVarP(&options.all_branches, "all-branches", "B", false, "Pull all branches on specific commit instead of just working branch")
+	cmdPush.Flags().BoolVarP(&options.all_branches, "all-branches", "B", false, "Push all branches on specific commit instead of just working branch")
 	cmdPurge.Flags().BoolVarP(&options.force, "dangling", "d", false, "Remove dangling images")
-	cmdPull.Flags().BoolVar(&pullOptions.pull_branch_tags, "pull-branch-tags", true, "Pull the 'branch' docker tags")
-	cmdPull.Flags().BoolVar(&pullOptions.enable_commit_id, "enable-commit-id", false, "Enable pulling commit-id tag image")
-	cmdPush.Flags().BoolVar(&pushOptions.enable_commit_id, "enable-commit-id", false, "Enable pushing commit-id tag image")
+	cmdPull.Flags().BoolVarP(&options.branch_tags, "branch-tags", "b", true, "Pull the 'branch' docker tags")
+	cmdPush.Flags().BoolVarP(&options.branch_tags, "branch-tags", "b", true, "Push the 'branch' docker tags")
+	cmdPull.Flags().BoolVarP(&options.commit_tags, "commit-tags", "c", false, "Pull the 'commit' docker tags")
+	cmdPush.Flags().BoolVarP(&options.commit_tags, "commit-tags", "c", false, "Push the 'commit' docker tags")
 	captainCmd.AddCommand(cmdBuild, cmdTest, cmdPush, cmdPull, cmdVersion, cmdPurge)
 	captainCmd.Execute()
 }


### PR DESCRIPTION
* Moved `--all-branches` flag to `build` `push` and `pull` subcommands instead of being global.
* Renamed `--pull-branch-tags` flag to less verbose `--branch-tags` and added it to both `push` and `pull` subcommands.
* Added `--commit-tags` flag to `push` and `pull` subcommands.