### PR TITLE
Issue 30 Add support for build args

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ hello-world-test:
   test:
     - docker run -e NODE_ENV=TEST harbur/hello-world-test node mochaTest
     - docker run -e NODE_ENV=TEST harbur/hello-world-test node karmaTest
+buildargs:
+  build: Dockerfile
+  image: harbur/buildargs
+  build_arg:
+    keyname: keyvalue
 ```
 
 ### image
@@ -112,6 +117,15 @@ A list of commands that are run as post-execution after the compilation of the s
 ```yaml
 post:
   - echo "Reporting after compilation"
+```
+
+### build_arg
+
+A set of key values that are passed to docker build as `--build-arg` flag. For more information about build-args see [here](https://docs.docker.com/engine/reference/commandline/build/).
+
+```yaml
+build_arg:
+  keyname: keyvalue
 ```
 
 ## CLI Commands

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ hello-world-test:
   test:
     - docker run -e NODE_ENV=TEST harbur/hello-world-test node mochaTest
     - docker run -e NODE_ENV=TEST harbur/hello-world-test node karmaTest
-buildargs:
+project-with-build-args:
   build: Dockerfile
   image: harbur/buildargs
   build_arg:

--- a/config.go
+++ b/config.go
@@ -36,11 +36,12 @@ var configOrder *yaml.MapSlice
 
 // App struct
 type App struct {
-	Build string
-	Image string
-	Pre   []string
-	Post  []string
-	Test  []string
+	Build     string
+	Image     string
+	Pre       []string
+	Post      []string
+	Test      []string
+	Build_arg map[string]string
 }
 
 // configFile returns the file to read the config from.

--- a/test/buildArgs/Dockerfile
+++ b/test/buildArgs/Dockerfile
@@ -1,0 +1,4 @@
+FROM alpine:3.3
+ARG NODE_ENV=production
+RUN echo $NODE_ENV > /etc/node_env
+CMD ["sh", "-c", "cat /etc/node_env"]

--- a/test/buildArgs/captain.yml
+++ b/test/buildArgs/captain.yml
@@ -1,0 +1,10 @@
+buildargs:
+  build: Dockerfile
+  image: harbur/buildargs
+  build_arg:
+    NODE_ENV: production
+buildargs-test:
+  build: Dockerfile
+  image: harbur/buildargs-test
+  build_arg:
+    NODE_ENV: test


### PR DESCRIPTION
Fixes #30 

Added support for build args in captain.yaml format

Example of captain.yaml:

```
hello-world:
  build: Dockerfile
  image: harbur/hello-world
  build_arg:
    NODE_ENV: production
```
