### PR TITLE
Issue 28 Support Private parent images

### DIFF
--- a/docker.go
+++ b/docker.go
@@ -40,6 +40,13 @@ func buildImage(app App, tag string, force bool) error {
 		OutputStream:        os.Stdout,
 		ContextDir:          filepath.Dir(app.Build),
 	}
+
+	// Use ~/.docker/ auth configuration if exists
+	dockercfg, _ := docker.NewAuthConfigurationsFromDockerCfg()
+	if dockercfg != nil {
+		opts.AuthConfigs = *dockercfg
+	}
+
 	err := client.BuildImage(opts)
 	if err != nil {
 		fmt.Printf("%s", err)


### PR DESCRIPTION
Fixes #28

In order for captain to be able to download parent images during docker build it needs to instruct docker client to use ~/.docker/ configuration if it exists.
