### PR TITLE
Update installation process

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,11 +16,14 @@ From the other side, you can now pull the feature branch you want to test, or cr
 
 ## Installation
 
-To install Captain, run the following commands:
-
+To install Captain, run:
 ```
-curl -L https://github.com/harbur/captain/releases/download/v0.8.0/captain-`uname -s`-`uname -m` > /usr/local/bin/captain
-chmod +x /usr/local/bin/captain
+curl -sSL https://raw.githubusercontent.com/harbur/captain/v0.8.0/install.sh | bash
+```
+
+You will need to add `~/.captain/bin` in your `PATH`. E.g. in your `.bashrc` or `.zshrc` add:
+```
+export PATH=$HOME/.captain/bin:$PATH
 ```
 
 ## Captain.yml Format

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,44 @@
+#!/usr/bin/env bash
+
+set -e
+
+function getDistributionTag {
+    local ext=""
+    if [[ `uname -m` == "386" ]]; then
+        machine="386"
+    else
+        machine="amd64"
+    fi
+
+    if [[ `uname -s` == "Darwin" ]]; then
+        kernel="darwin"
+    elif [[ `uname -s` =~ CYGWIN*|MINGW32*|MSYS* ]]; then
+        kernel="windows"
+        ext=".exe"
+    else
+        kernel="linux"
+    fi
+
+    echo "captain_${kernel}_${machine}${ext}"
+}
+
+CAPTAIN_DIR=$HOME/.captain
+CAPTAIN_BIN_DIR=$CAPTAIN_DIR/bin
+CAPTAIN_BINARIES_DIR=$CAPTAIN_DIR/binaries
+CAPTAIN_CURRENT_VERSION_URL=$(curl -sS https://raw.githubusercontent.com/harbur/captain/master/VERSION)
+CAPTAIN_CURRENT_VERSION_PATH="${CAPTAIN_BINARIES_DIR}/captain-${CAPTAIN_CURRENT_VERSION_URL}"
+CAPTAIN_DISTRIBUTION=$(getDistributionTag)
+
+
+echo "Creating folders in ${CAPTAIN_DIR}"
+mkdir -p $CAPTAIN_BIN_DIR $CAPTAIN_BINARIES_DIR
+
+echo "Start downloading Captain ${CAPTAIN_CURRENT_VERSION_URL}"
+curl -sSL https://github.com/harbur/captain/releases/download/${CAPTAIN_CURRENT_VERSION_URL}/${CAPTAIN_DISTRIBUTION} > ${CAPTAIN_CURRENT_VERSION_PATH}
+ln -snf ${CAPTAIN_CURRENT_VERSION_PATH} "${CAPTAIN_BIN_DIR}/captain"
+
+echo "Captain ${CAPTAIN_CURRENT_VERSION_URL} installed"
+echo ""
+echo "IMPORTANT: Add ${CAPTAIN_BIN_DIR} in your path. E.g.:"
+echo "export PATH=${CAPTAIN_BIN_DIR}:\$PATH"
+


### PR DESCRIPTION
In order to have the directories needed to run `captain self-update` we need to improve the installation process.

This PR add the `installation.sh` script that creates the captain folders and download the last available version of captain. 

Updated installation process in the `readme`.

This closes #52 