### PR TITLE
Delimiter can be passed via namespace

### DIFF
--- a/config.go
+++ b/config.go
@@ -207,7 +207,11 @@ func visit(namespace string) filepath.WalkFunc {
 			// Get Parent Dirname
 			absolutePath, _ := filepath.Abs(path)
 			var image = strings.ToLower(filepath.Base(filepath.Dir(absolutePath)))
-			imagesMap[path] = namespace + "/" + image + strings.ToLower(filepath.Ext(path))
+			delimitedNamespace := namespace
+			if !strings.Contains(namespace, "/") {
+				delimitedNamespace += "/"
+			}
+			imagesMap[path] = delimitedNamespace + image + strings.ToLower(filepath.Ext(path))
 			debug("Located %s will be used to create %s", path, imagesMap[path])
 		}
 		return nil


### PR DESCRIPTION
I wanted to deploy my images using a certain user and a prefix to the docker tag, however if I placed a `/` it was erroring.

This PR basically allows the following:

```
captain build -N xyz/something-
```

to build like so:

```
xyz/something-dashboard:latest
```