### PR TITLE
Exit after test failure

### DIFF
--- a/captain.go
+++ b/captain.go
@@ -156,7 +156,7 @@ func Test(opts BuildOptions) {
 			res := execute("bash", "-c", value)
 			if res != nil {
 				err("Test execution returned non-zero status")
-				return
+				os.Exit(ExecuteFailed)
 			}
 		}
 	}


### PR DESCRIPTION
```
 ~/my-project $ captain test && echo success
[CAPTAIN] Test execution returned non-zero status
success
```

I am not sure how to change test file and I could not make the new binary:
```
2017-06-16 10:04:58 ~/workspace/captain feature/fix-test-command-exit-code $make
docker build -t harbur/captain .
Sending build context to Docker daemon  801.8kB
....
Fetching https://gopkg.in/yaml.v2?go-get=1
Parsing meta tags from https://gopkg.in/yaml.v2?go-get=1 (status code 200)
get "gopkg.in/yaml.v2": found meta tag main.metaImport{Prefix:"gopkg.in/yaml.v2", VCS:"git", RepoRoot:"https://gopkg.in/yaml.v2"} at https://gopkg.in/yaml.v2?go-get=1
gopkg.in/yaml.v2 (download)
The command '/bin/sh -c go-wrapper download' returned a non-zero code: 1
make: *** [build] Error 1
```