### PR TITLE
Fix tag format of container when building tag

### DIFF
--- a/git.go
+++ b/git.go
@@ -20,7 +20,7 @@ func getBranches(all_branches bool) []string {
 	// Labels (branches + tags)
 	var labels = []string{}
 
-	branches_str, _ := oneliner("git", "name-rev", "--name-only", "HEAD")
+	branches_str, _ := oneliner("git", "name-rev", "--name-only", "--exclude=tags/*", "HEAD")
 	if all_branches {
 		branches_str, _ = oneliner("git", "branch", "--no-column", "--contains", "HEAD")
 	}


### PR DESCRIPTION
Another PR that addresses #63.

Doing a `captain build` when on a tagged commit currently causes a
erroneous tag name. For example, if on a tag v1.0 of a repository, when
the captain build occurs, this this the output:

```
[CAPTAIN] Skipping build of image my_organization/my_image_name:da5ewb3 - image is already built
[CAPTAIN] Tagging image my_organization/my_image_name:da5ewb3 as my_organization/my_image_name:latest
[CAPTAIN] Tagging image my_organization/my_image_name:da5ewb3 as my_organization/my_image_name:tags.v1.0^0
API error (500): {"message":"invalid tag format"}
```

Notice the `tags.v1.0^0`. That is wrong on two fronts. 1.) the tag should
be `v1.0` and 2.) the carrot symbol `^` makes it an invalid format for a
docker tag.

The problem occurs when obtaining the branch names. The code uses the
command `git name-rev --name-only HEAD` to determine the branch name.
This used to work. However, git must have changed over the years because
if you are on a tag, this now returns `tags.v1.0^0`.

Fortunately, the same command has an `--exclude` parameter that will
allow us to indicate to filter out tags (which is what we wanted anyway
for that particular call). The tags are determined later via the git
command `git tag --points-at HEAD`. (all of these references occur in
`git.go`)

When running tests, as they currently are, they failed for this very
reason. After excluding tags with the `--exclude` parameter to the git
command, all the tests pass. (I am running git version 2.17.1 on Ubuntu
18.04)

Please accept this PR and create a new distributable so I and others do
not run into this again.